### PR TITLE
PyPI Freshness Checker

### DIFF
--- a/scripts/dev/seed_users_login_info.py
+++ b/scripts/dev/seed_users_login_info.py
@@ -1,0 +1,121 @@
+"""Seed login-info rows for IP retention cleanup testing.
+
+Usage:
+    uv run invenio shell scripts/dev/seed_old_login_info.py
+
+The script updates every existing accounts_user row with repeating retention
+test cases. It does not create users.
+"""
+
+from datetime import datetime, timedelta, timezone
+from itertools import cycle
+from random import Random
+
+from flask import current_app
+from invenio_accounts.models import User
+from invenio_accounts.proxies import current_datastore
+from invenio_db import db
+
+
+RANDOM_SEED = 20260610
+
+
+def _retention_dates():
+    """Return timestamps just outside and inside the configured retention window."""
+    retention_period = current_app.config["ACCOUNTS_RETENTION_PERIOD"]
+    expires_before = datetime.now(timezone.utc) - retention_period
+    return {
+        "expired": expires_before - timedelta(days=1),
+        "recent": datetime.now(timezone.utc),
+    }
+
+
+def _seed_specs():
+    """Build seed users for each retention cleanup case."""
+    dates = _retention_dates()
+    return [
+        {
+            "last_login_at": dates["expired"],
+            "current_login_at": dates["expired"],
+            "last_login_ip": "198.51.100.10",
+            "current_login_ip": "198.51.100.11",
+        },
+        {
+            "last_login_at": dates["recent"],
+            "current_login_at": dates["recent"],
+            "last_login_ip": "198.51.100.20",
+            "current_login_ip": "198.51.100.21",
+        },
+        {
+            "last_login_at": dates["expired"],
+            "current_login_at": dates["recent"],
+            "last_login_ip": "198.51.100.30",
+            "current_login_ip": "198.51.100.31",
+        },
+        {
+            "last_login_at": dates["recent"],
+            "current_login_at": dates["expired"],
+            "last_login_ip": "198.51.100.40",
+            "current_login_ip": "198.51.100.41",
+        },
+        {
+            "last_login_at": dates["expired"],
+            "current_login_at": dates["expired"],
+            "last_login_ip": None,
+            "current_login_ip": None,
+        },
+    ]
+
+
+def _existing_users():
+    """Return every existing user account."""
+    return db.session.query(User).order_by(User.id).all()
+
+
+def _update_login_info(user, spec, login_count):
+    """Apply the login tracking fields to a user."""
+    user.last_login_at = spec["last_login_at"]
+    user.current_login_at = spec["current_login_at"]
+    user.last_login_ip = spec["last_login_ip"]
+    user.current_login_ip = spec["current_login_ip"]
+    user.login_count = login_count
+
+    # LoginInformation changes are not User model changes, so mark the aggregate
+    # user as changed for the normal datastore post-commit indexing hooks.
+    current_datastore.mark_changed(id(db.session), model=user)
+
+
+def main():
+    """Seed all login-info retention cases."""
+    users = _existing_users()
+    spec_cycle = cycle(_seed_specs())
+    random = Random(RANDOM_SEED)
+    seeded = []
+
+    for user in users:
+        spec = next(spec_cycle)
+        login_count = random.randint(1, 500)
+        _update_login_info(user, spec, login_count)
+        seeded.append((user, spec, login_count))
+
+    current_datastore.commit()
+
+    print(f"Seeded IP retention login-info for {len(seeded)} existing users:")
+    for user, spec, login_count in seeded:
+        print(
+            "  "
+            f"updated: id={user.id} email={user.email} "
+            f"login_count={login_count} "
+            f"last=({spec['last_login_at'].isoformat()}, {spec['last_login_ip']}) "
+            f"current=({spec['current_login_at'].isoformat()}, "
+            f"{spec['current_login_ip']})"
+        )
+
+    print()
+    print("Run the retention task manually with:")
+    print("  uv run invenio shell")
+    print("  >>> from invenio_accounts.tasks import delete_ips")
+    print("  >>> delete_ips()")
+
+
+main()

--- a/scripts/dev/user-check-tools/check_users_login_info_index.py
+++ b/scripts/dev/user-check-tools/check_users_login_info_index.py
@@ -1,0 +1,183 @@
+"""Count DB and indexed user login-info fields for retention testing.
+
+Usage:
+    uv run invenio shell scripts/dev/user-check-tools/check_users_login_info_index.py
+"""
+
+from datetime import datetime, timezone
+
+from click import secho
+from flask import current_app
+from invenio_accounts.models import LoginInformation, User
+from invenio_db import db
+from invenio_search.proxies import current_search_client
+from invenio_users_resources.proxies import current_users_service
+from opensearch_dsl import Search
+from sqlalchemy import func, or_
+
+
+IP_FIELDS = (
+    ("last_login_ip", "last_login_at"),
+    ("current_login_ip", "current_login_at"),
+)
+
+
+def retention_cutoff():
+    """Return the same cutoff used by ``invenio_accounts.tasks.delete_ips``."""
+    return datetime.now(timezone.utc) - current_app.config["ACCOUNTS_RETENTION_PERIOD"]
+
+
+def count(query):
+    """Return a scalar SQL count."""
+    return query.scalar() or 0
+
+
+def db_count(ip_field=None, date_field=None, expired=False):
+    """Count DB login-info rows matching an IP-field condition."""
+    if ip_field is None:
+        return count(db.session.query(func.count(User.id)))
+
+    ip_column = getattr(LoginInformation, ip_field)
+    query = db.session.query(func.count(LoginInformation.user_id)).filter(
+        ip_column.isnot(None)
+    )
+
+    if expired:
+        query = query.filter(getattr(LoginInformation, date_field) < retention_cutoff())
+
+    return count(query)
+
+
+def indexed_name():
+    """Return the concrete latest-build users index, if it exists."""
+    index_name = current_users_service.record_cls.index._name
+    pattern = f"latest-build-{index_name}-*"
+    if not current_search_client.indices.exists(index=pattern):
+        return None
+
+    return next(iter(current_search_client.indices.get_alias(index=pattern).keys()))
+
+
+def search_count(index_name, query=None):
+    """Count indexed users matching an optional OpenSearch query."""
+    search = Search(using=current_search_client, index=index_name)
+    if query:
+        search = search.query(query)
+    return search.count()
+
+
+def exists_query(field):
+    """Build an exists query."""
+    return {"exists": {"field": field}}
+
+
+def expired_query(ip_field, date_field):
+    """Build an indexed expired-IP query."""
+    return {
+        "bool": {
+            "filter": [
+                exists_query(ip_field),
+                {"range": {date_field: {"lt": retention_cutoff().isoformat()}}},
+            ]
+        }
+    }
+
+
+def any_ip_query():
+    """Build an indexed any-IP-present query."""
+    return {
+        "bool": {
+            "should": [exists_query("last_login_ip"), exists_query("current_login_ip")],
+            "minimum_should_match": 1,
+        }
+    }
+
+
+def print_row(label, db_value, indexed_value=None, warn_nonzero=False):
+    """Print one report row."""
+    fg = "green"
+    if warn_nonzero and (db_value or indexed_value):
+        fg = "yellow"
+    if indexed_value is None:
+        secho(f"  {label}: db={db_value}", fg=fg)
+    else:
+        secho(f"  {label}: db={db_value} indexed={indexed_value}", fg=fg)
+
+
+def main():
+    """Print a compact before/after retention report."""
+    cutoff = retention_cutoff()
+    index_name = indexed_name()
+
+    secho("User login-info retention counts", fg="bright_blue", bold=True)
+    secho(f"  retention_cutoff: {cutoff.isoformat()}", fg="blue")
+    secho(f"  concrete_index: {index_name or 'missing'}", fg="blue")
+    secho("")
+
+    total_db = count(db.session.query(func.count(User.id)))
+    any_ip_db = count(
+        db.session.query(func.count(LoginInformation.user_id)).filter(
+            or_(
+                LoginInformation.last_login_ip.isnot(None),
+                LoginInformation.current_login_ip.isnot(None),
+            )
+        )
+    )
+
+    if index_name is None:
+        secho(
+            "OpenSearch users index is missing. Run the migration reindex script.",
+            fg="red",
+        )
+        print_row("users total", total_db)
+        print_row("users with any IP", any_ip_db)
+        return
+
+    current_search_client.indices.refresh(index=index_name)
+    print_row("users total", total_db, search_count(index_name))
+    print_row("users with any IP", any_ip_db, search_count(index_name, any_ip_query()))
+
+    db_ip_values = 0
+    indexed_ip_values = 0
+    db_expired_ip_values = 0
+    indexed_expired_ip_values = 0
+
+    for ip_field, date_field in IP_FIELDS:
+        db_present = db_count(ip_field)
+        indexed_present = search_count(index_name, exists_query(ip_field))
+        db_expired = db_count(ip_field, date_field, expired=True)
+        indexed_expired = search_count(index_name, expired_query(ip_field, date_field))
+
+        db_ip_values += db_present
+        indexed_ip_values += indexed_present
+        db_expired_ip_values += db_expired
+        indexed_expired_ip_values += indexed_expired
+
+        print_row(
+            f"{ip_field} present",
+            db_present,
+            indexed_present,
+        )
+        print_row(
+            f"{ip_field} expired and present",
+            db_expired,
+            indexed_expired,
+            warn_nonzero=True,
+        )
+
+    secho("")
+    print_row("IP values present total", db_ip_values, indexed_ip_values)
+    print_row(
+        "expired IP values present total",
+        db_expired_ip_values,
+        indexed_expired_ip_values,
+        warn_nonzero=True,
+    )
+
+    secho("")
+    secho(
+        "After delete_ips + reindex, expired-and-present rows should be 0.", fg="blue"
+    )
+
+
+main()

--- a/scripts/dev/user-check-tools/seed_users_login_info.py
+++ b/scripts/dev/user-check-tools/seed_users_login_info.py
@@ -1,7 +1,7 @@
 """Seed login-info rows for IP retention cleanup testing.
 
 Usage:
-    uv run invenio shell scripts/dev/seed_old_login_info.py
+    uv run invenio shell scripts/dev/seed_users_login_info.py
 
 The script updates every existing accounts_user row with repeating retention
 test cases. It does not create users.
@@ -111,6 +111,14 @@ def main():
             f"{spec['current_login_ip']})"
         )
 
+    print()
+    print("Rebuild the user/group indices with the known-good migration script:")
+    print(
+        "  uv run invenio shell scripts/indices-migration-v13-14/user-groups-indices-migration.py"
+    )
+    print()
+    print("Then check indexed counts with:")
+    print("  uv run invenio shell scripts/dev/check_users_login_info_index.py")
     print()
     print("Run the retention task manually with:")
     print("  uv run invenio shell")

--- a/scripts/dev/user-check-tools/seed_users_login_info.py
+++ b/scripts/dev/user-check-tools/seed_users_login_info.py
@@ -1,10 +1,27 @@
 """Seed login-info rows for IP retention cleanup testing.
 
 Usage:
-    uv run invenio shell scripts/dev/seed_users_login_info.py
+    uv run invenio shell scripts/dev/user-check-tools/seed_users_login_info.py
 
 The script updates every existing accounts_user row with repeating retention
 test cases. It does not create users.
+
+The seed script updates every existing user, but it does not populate every IP field for every user. Some NULLs are intentional.
+It cycles through 5 test cases repeatedly:
+Expired last + expired current
+Both IPs populated. Both should be deleted by delete_ips.
+
+Recent last + recent current
+Both IPs populated. Neither should be deleted.
+
+Expired last + recent current
+Both IPs populated, but only last_login_ip should be deleted.
+
+Recent last + expired current
+Both IPs populated, but only current_login_ip should be deleted.
+
+Expired timestamps + NULL IPs
+Both IPs are intentionally NULL. This tests that rows with already-null IPs do not break cleanup.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -13,7 +30,6 @@ from random import Random
 
 from flask import current_app
 from invenio_accounts.models import User
-from invenio_accounts.proxies import current_datastore
 from invenio_db import db
 
 
@@ -80,10 +96,6 @@ def _update_login_info(user, spec, login_count):
     user.current_login_ip = spec["current_login_ip"]
     user.login_count = login_count
 
-    # LoginInformation changes are not User model changes, so mark the aggregate
-    # user as changed for the normal datastore post-commit indexing hooks.
-    current_datastore.mark_changed(id(db.session), model=user)
-
 
 def main():
     """Seed all login-info retention cases."""
@@ -98,7 +110,7 @@ def main():
         _update_login_info(user, spec, login_count)
         seeded.append((user, spec, login_count))
 
-    current_datastore.commit()
+    db.session.commit()
 
     print(f"Seeded IP retention login-info for {len(seeded)} existing users:")
     for user, spec, login_count in seeded:
@@ -118,7 +130,9 @@ def main():
     )
     print()
     print("Then check indexed counts with:")
-    print("  uv run invenio shell scripts/dev/check_users_login_info_index.py")
+    print(
+        "  uv run invenio shell scripts/dev/user-check-tools/check_users_login_info_index.py"
+    )
     print()
     print("Run the retention task manually with:")
     print("  uv run invenio shell")

--- a/scripts/pypi_freshness_check.py
+++ b/scripts/pypi_freshness_check.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+
+"""
+PyPI Package Freshness Checker
+===============================
+
+Check the "freshness" of your Python packages - like checking if fruit is too old!
+This script compares your installed package versions against PyPI to show both their
+ages and highlight packages with recent updates available.
+
+Features:
+---------
+- Color-coded output based on package age (like a freshness indicator)
+- Shows both current and latest version ages
+- Configurable sorting (by current or latest version age)
+- Parallel API requests for fast execution
+- Works with uv-managed and pip-managed virtual environments
+
+Usage:
+------
+# Basic usage (uses active venv from $VIRTUAL_ENV):
+uv run ./pypi_freshness_check.py
+
+# Specify a different virtual environment:
+./pypi_freshness_check.py --venv /path/to/.venv
+
+# Sort by latest version age to see recent PyPI releases:
+uv run ./pypi_freshness_check.py --sort-by latest
+
+# Adjust number of parallel workers:
+uv run ./pypi_freshness_check.py --workers 16
+
+Color Coding:
+-------------
+The output is color-coded based on the age matching your sort option:
+- When sorting by current (default): Colors show current version age
+- When sorting by latest: Colors show latest version age
+
+Color meanings:
+- RED:    Released today (0 days ago)
+- ORANGE: Released yesterday (1 day ago)
+- YELLOW: Released 2-3 days ago
+- BLUE:   Released 4-7 days ago
+- NORMAL: Released 8+ days ago
+
+Columns:
+--------
+- Package:      Package name
+- Current:      Your currently installed version
+- Current Age:  How long ago your installed version was released
+- Latest:       Latest available version on PyPI
+- Latest Age:   How long ago the latest version was released
+
+Sorting Options:
+----------------
+--sort-by current (default): Sorts by current version age (shows your newest installed packages first)
+--sort-by latest:           Sorts by latest version age (shows packages with newest releases first)
+
+Examples:
+---------
+# Find packages with recent updates available:
+uv run ./check_pypi_release_date.py
+
+# Find which of your installed packages are oldest:
+uv run ./check_pypi_release_date.py --sort-by current
+
+# Check another environment:
+./check_pypi_release_date.py --venv ~/.virtualenvs/myproject/.venv
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+# ANSI colors
+RED = "\033[31m"
+ORANGE = "\033[38;5;208m" 
+YELLOW = "\033[33m"
+BLUE = "\033[94m"
+GRAY = "\033[90m"
+RESET = "\033[0m"
+
+def run(cmd: str) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True)
+
+def freeze_cmd(venv: str | None) -> str:
+    """Prefer uv pip; fall back to pip from chosen environment."""
+    # If uv is available, use it directly (works with uv-managed venvs)
+    if shutil.which("uv"):
+        return "uv pip freeze"
+    # Fall back to regular pip
+    if venv:
+        py = os.path.join(venv, "bin", "python")
+        return f'"{py}" -m pip freeze'
+    return f'"{sys.executable}" -m pip freeze'
+
+def parse_freeze(text: str):
+    pkgs = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("-e ") or "@" in line:
+            continue
+        if "==" in line:
+            name, version = line.split("==", 1)
+            if name and version:
+                pkgs.append((name, version))
+    return pkgs
+
+def iso_to_epoch(s: str | None) -> float | None:
+    if not s:
+        return None
+    try:
+        # prefer the part before '.' to avoid subsecond parsing quirks
+        s = s.replace("Z", "+00:00")
+        if "." in s and "+" in s:
+            # keep timezone, strip subseconds
+            left, right = s.split("+", 1)
+            s = left.split(".", 1)[0] + "+" + right
+        elif "." in s:
+            s = s.split(".", 1)[0]
+        return datetime.fromisoformat(s).timestamp()
+    except Exception:
+        return None
+
+def fetch_latest(name: str, current_version: str):
+    """Return (latest_version, latest_upload_iso, latest_days, current_upload_iso, current_days) or (None, None, None, None, None) on failure."""
+    # Try exact name first, then PEP 503 normalized
+    candidates = [name, name.replace("_", "-").lower()]
+    for n in candidates:
+        # Strip control chars to avoid jq-like failures
+        proc = run(f'curl -sSfL https://pypi.org/pypi/{n}/json | tr -d "\\000-\\037"')
+        if proc.returncode != 0 or not proc.stdout:
+            continue
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            continue
+        latest = (data.get("info") or {}).get("version")
+        if not latest:
+            continue
+        
+        releases = data.get("releases") or {}
+        
+        # Get latest version info
+        latest_files = releases.get(latest, [])
+        latest_ts = None
+        latest_picked = None
+        for f in latest_files:
+            u = f.get("upload_time_iso_8601") or f.get("upload_time")
+            e = iso_to_epoch(u)
+            if e is not None and (latest_ts is None or e > latest_ts):
+                latest_ts = e
+                latest_picked = u
+        
+        latest_days = None
+        if latest_picked and latest_ts:
+            now = datetime.now(timezone.utc).timestamp()
+            latest_days = int((now - latest_ts) // 86400)
+        
+        # Get current version info
+        current_files = releases.get(current_version, [])
+        current_ts = None
+        current_picked = None
+        for f in current_files:
+            u = f.get("upload_time_iso_8601") or f.get("upload_time")
+            e = iso_to_epoch(u)
+            if e is not None and (current_ts is None or e > current_ts):
+                current_ts = e
+                current_picked = u
+        
+        current_days = None
+        if current_picked and current_ts:
+            now = datetime.now(timezone.utc).timestamp()
+            current_days = int((now - current_ts) // 86400)
+        
+        return latest, latest_picked, latest_days, current_picked, current_days
+    
+    return None, None, None, None, None
+
+def color_for_days(days: int | None) -> str:
+    if days is None:
+        return RESET
+    if days == 0:
+        return RED
+    if days == 1:
+        return ORANGE
+    if 2 <= days <= 3:
+        return YELLOW
+    if 4 <= days <= 7:
+        return BLUE
+    return RESET
+
+def group_rank(days: int | None) -> int:
+    if days is None:
+        return 5
+    if days == 0:
+        return 0
+    if days == 1:
+        return 1
+    if 2 <= days <= 3:
+        return 2
+    if 4 <= days <= 7:
+        return 3
+    return 4  # 8+ days
+
+def main():
+    parser = argparse.ArgumentParser(description="Show latest PyPI releases by recency (color-coded).")
+    parser.add_argument("--venv", help="Path to a virtualenv to inspect (defaults to the active venv).")
+    parser.add_argument("--workers", type=int, default=min(32, (os.cpu_count() or 8) * 4),
+                        help="Parallel requests (default: CPU*4, max 32).")
+    parser.add_argument("--sort-by", choices=["current", "latest"], default="current",
+                        help="Sort by 'current' version age or 'latest' version age (default: current).")
+    args = parser.parse_args()
+
+    active_venv = args.venv or os.environ.get("VIRTUAL_ENV")
+    env_label = active_venv or os.path.dirname(sys.executable)
+
+    print(f"{GRAY}Using Python {'.'.join(map(str, sys.version_info[:3]))}  environment at: {env_label}")
+    print()
+    print("this is unsorted output - see final summary below")
+    print(f"{RESET}")
+
+    # Get freeze list
+    proc = run(freeze_cmd(active_venv))
+    if proc.returncode != 0:
+        print(proc.stderr or "Failed to run pip freeze", file=sys.stderr)
+        sys.exit(1)
+    pkgs = parse_freeze(proc.stdout)
+    if not pkgs:
+        print("No packages found.")
+        sys.exit(0)
+
+    # Column widths (fixed once so live output aligns)
+    name_w = max( len("Package"), max(len(n) for n,_ in pkgs) ) + 2
+    cur_w  = max( len("Current"), max(len(v) for _,v in pkgs) ) + 2
+    latest_w = max( len("Latest"), cur_w ) + 2
+    cur_age_w = 18  # "released XXX days"
+    latest_age_w = 18  # "released XXX days"
+
+    header = f"{'Package':<{name_w}} {'Current':<{cur_w}} {'Current Age':<{cur_age_w}} {'Latest':<{latest_w}} {'Latest Age':<{latest_age_w}}"
+    rule = "-" * (name_w + cur_w + cur_age_w + latest_w + latest_age_w + 4)
+    print(f"{GRAY}{header}")
+    print(rule)
+    print(f"{RESET}")
+
+    results = []
+
+    def work(item):
+        name, cur = item
+        latest, latest_upload, latest_days, current_upload, current_days = fetch_latest(name, cur)
+        return (name, cur, latest, latest_upload, latest_days, current_upload, current_days)
+
+    # Parallel fetch & live print
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futures = {ex.submit(work, it): it for it in pkgs}
+        for fut in as_completed(futures):
+            name, cur, latest, latest_upload, latest_days, current_upload, current_days = fut.result()
+            results.append((name, cur, latest, latest_upload, latest_days, current_upload, current_days))
+            # Gray output for unsorted live results
+            cur_when = f"{current_days} days ago" if current_days is not None else "N/A"
+            latest_when = f"{latest_days} days ago" if latest_days is not None else "N/A"
+            latest_disp = latest or "N/A"
+            print(f"{GRAY}{name:<{name_w}} {cur:<{cur_w}} {cur_when:<{cur_age_w}} {latest_disp:<{latest_w}} {latest_when:<{latest_age_w}}{RESET}")
+            sys.stdout.flush()
+
+    # Final sorted summary
+    print("\n" + "=" * (len(rule)))
+    if args.sort_by == "current":
+        print("Sorted by CURRENT version age (newest first):")
+        print("use --sort-by latest to see packages with newest releases first")
+        print("Color indicates CURRENT version age - Red: today | Orange: 1 day | Yellow: 2-3 days | Blue: 4-7 days | Normal: 8+ days\n")
+        sort_index = 6  # current_days
+    else:
+        print("Sorted by LATEST version age (newest first):")
+        print("use --sort-by current or remove the --sort-by option to see packages with newest installed versions first")
+        print("Color indicates LATEST version age - Red: today | Orange: 1 day | Yellow: 2-3 days | Blue: 4-7 days | Normal: 8+ days\n")
+        sort_index = 4  # latest_days
+    
+    print(header)
+    print(rule)
+
+    for name, cur, latest, latest_upload, latest_days, current_upload, current_days in sorted(
+        results,
+        key=lambda r: (group_rank(r[sort_index]), r[sort_index] if r[sort_index] is not None else 10**9, r[0].lower())
+    ):
+        color_days = current_days if args.sort_by == "current" else latest_days
+        color = color_for_days(color_days)
+        cur_when = f"{current_days} days ago" if current_days is not None else "N/A"
+        latest_when = f"{latest_days} days ago" if latest_days is not None else "N/A"
+        latest_disp = latest or "N/A"
+        print(f"{color}{name:<{name_w}} {cur:<{cur_w}} {cur_when:<{cur_age_w}} {latest_disp:<{latest_w}} {latest_when:<{latest_age_w}}{RESET}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a new developer utility script pypi_freshness_check.py that extends beyond existing tools like pip list --outdated, piprot, and pip-outdated.

Unlike those tools, this checker:

* Works directly on the active environment (or a specified venv)
* Fetches package metadata in parallel for speed
* Shows both installed and latest version release ages
* Adds clear color-coded freshness indicators (red/orange/yellow/blue)
* Sorts by recency to quickly spot newly released or potentially breaking updates
* This helps maintainers identify recent upstream changes that could affect test stability or CI reproducibility.

`uv run ./scripts/pypi_freshness_check.py --sort-by latest`
<img width="838" height="812" alt="Screenshot 2025-10-09 at 01 09 54" src="https://github.com/user-attachments/assets/7131f43b-8fa8-4520-acad-1627604efafe" />

`uv run ./scripts/pypi_freshness_check.py `
<img width="850" height="1080" alt="Screenshot 2025-10-09 at 01 11 49" src="https://github.com/user-attachments/assets/a0b1e470-7a90-4dbc-af49-e28f2021e839" />

