### PR TITLE
fix: use caching to fetch role id

### DIFF
--- a/site/latest_build/permissions.py
+++ b/site/latest_build/permissions.py
@@ -14,17 +14,17 @@ from flask_principal import RoleNeed
 from invenio_administration.generators import Administration
 from invenio_communities.permissions import CommunityPermissionPolicy
 from invenio_records_permissions.generators import Disable, Generator, SystemProcess
-from invenio_accounts.proxies import current_datastore
+from invenio_accounts.utils import resolve_role_id
 
 class CommunityCreator(Generator):
-    """Allows users with the community-creator role."""
+    """Allows users with the configured community-creator role."""
 
     def needs(self, **kwargs):
         configured = current_app.config.get(
             "CONFIG_COMMUNITY_CREATOR_ROLE", "community-creator"
         )
-        role = current_datastore.find_role(configured)
-        return [RoleNeed(role.id)] if role else [RoleNeed(configured)]
+        role_id = resolve_role_id(configured)
+        return [RoleNeed(role_id) if role_id else RoleNeed(configured)]
 
 
 class CommunitiesPermissionPolicy(CommunityPermissionPolicy):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Refactor role retrieval to use resolve_role_id for consistency and clarity.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
